### PR TITLE
Get SCTP working

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Assuming that the kernel source code directory is `~/head/` use
 cd multistack/sys/contrib/multistack
 env SYSDIR=~/head/sys make
 ````
+If you also want SCTP support, you need to do
+````
+echo "#define SCTP 1" > opt_sctp.h
+env SYSDIR=~/head/sys make
+````
+
 ## Author
 
 Michio Honda (firstname@netapp.com)

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ For more details, see multistack/examples/pkt-gen.c (a modified version of netma
 	
 ## How to Build the Code (FreeBSD)
 
-Assuming that the kernel source code directory is `/home/tuexen/head/sys` use
+Assuming that the kernel source code directory is `~/head/` use
 ````
 cd multistack/sys/contrib/multistack
-env SYSDIR=/home/tuexen/head/sys make
+env SYSDIR=~/head/sys make
 ````
 ## Author
 

--- a/sys/contrib/multistack/multistack.c
+++ b/sys/contrib/multistack/multistack.c
@@ -651,7 +651,9 @@ ms_pcb_clash(struct sockaddr *sa, uint8_t protocol)
 				D("%s:%u is not bound", buf, ntohs(sin->sin_port));
 				error = ENOENT;
 			} else {
+				INP_RLOCK(inp);
 				error = cr_canseeinpcb(curthread->td_ucred, inp);
+				INP_RUNLOCK(inp);
 				if (error) {
 					D("%s:%u is not mine", buf, ntohs(sin->sin_port));
 				}


### PR DESCRIPTION
This patch gets SCTP working. It fixes a dereference issue and adds the appropriate locking.
It also tells you how to build it on FreeBSD with SCTP support.