### PR TITLE
Improve FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,13 @@ For more details, see multistack/examples/pkt-gen.c (a modified version of netma
 	
 ## How to Build the Code (FreeBSD)
 
-Assuming that the kernel source code directory is `~/head/` use
+Assuming that the kernel source code directory is `/home/tuexen/head/` use
 ````
 cd multistack/sys/contrib/multistack
-env SYSDIR=~/head/sys make
+env SYSDIR=/home/tuexen/head/sys make
 ````
-If you also want SCTP support, you need to do
-````
-echo "#define SCTP 1" > opt_sctp.h
-env SYSDIR=~/head/sys make
-````
+
+Please note that you need r285877 or higher of the FreeBSD HEAD sources [(see patch)](https://svnweb.freebsd.org/changeset/base/285877) to get multistack compiling with SCTP support.
 
 ## Author
 

--- a/sys/contrib/multistack/Makefile
+++ b/sys/contrib/multistack/Makefile
@@ -1,13 +1,9 @@
 .PATH: .
 KMOD=	multistack
 SRCS=	multistack.c
-SRCS+=	opt_inet.h opt_inet6.h opt_sctp.h opt_compat.h opt_ipsec.h
 TARGET!=	uname -m
 IDENT!=		uname -i
-CFLAGS+= -I$(KSRC)
-CFLAGS+= -I../../../sys/
 CFLAGS+= -I../../
-CFLAGS+= -I$(KSRC)/sys/$(TARGET)/compile/$(IDENT)
-CFLAGS+= $(NMVER)
+CFLAGS+= -I$(SYSDIR)/$(TARGET)/compile/$(IDENT)
 
 .include <bsd.kmod.mk>


### PR DESCRIPTION
This patch improves the makefile to use the opt_*.h files used in the kernel build directory. Update the README to reflect this. Please note that this enables SCTP support on all kernels supporting SCTP.